### PR TITLE
itemテーブル　外部キー設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
 
   def  show
     @item = Item.find(params[:id])
-    @profile = Profile.find(params[:id])
+    @user = User.find(current_user.id)
   end
 
   def destroy
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-    params.require(:item).permit(:name, :text, :price, :category, :condition, :postage_payer, :prefecture_id, :standby_day, :trading_status, images_attributes: [:image_url]).merge(seller_id: current_user.id)
+    params.require(:item).permit(:name, :text, :price, :category, :condition, :postage_payer, :prefecture_id, :standby_day, :trading_status, :buyer_id, images_attributes: [:image_url]).merge(seller_id: current_user.id)
   end
 
   def set_item

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,9 +13,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-     redirect_to :items_index
+      redirect_to root_path
     else
-     render 'new'
+      render :new
     end
   end
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -54,8 +54,7 @@
                   %th
                     出品者
                   %td
-                    = @profile.family_name
-                    = @profile.first_name
+                    = @user.nickname
                 %tr
                   %th
                     カテゴリー

--- a/db/migrate/20200708025230_create_items.rb
+++ b/db/migrate/20200708025230_create_items.rb
@@ -10,8 +10,8 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :prefecture
       t.string :standby_day
       t.string :trading_status
-      t.integer :seller
-      t.integer :buyer
+      t.references :seller, null: false, foreign_key: { to_table: :users }
+      t.references :buyer, foreign_key: { to_table: :users }
       t.timestamps
     end
   end

--- a/db/migrate/20200717012125_change_column_to_item.rb
+++ b/db/migrate/20200717012125_change_column_to_item.rb
@@ -1,6 +1,0 @@
-class ChangeColumnToItem < ActiveRecord::Migration[6.0]
-  def change
-    remove_index :items, :seller_id
-    remove_reference :items, :seller
-  end
-end

--- a/db/migrate/20200717012342_add_seller_to_items.rb
+++ b/db/migrate/20200717012342_add_seller_to_items.rb
@@ -1,6 +1,0 @@
-class AddSellerToItems < ActiveRecord::Migration[6.0]
-  def change
-    add_reference :items, :seller, foreign_key: { to_table: :users }
-    add_column :items, :seller
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,11 +29,11 @@ ActiveRecord::Schema.define(version: 2020_07_17_012342) do
     t.integer "prefecture_id"
     t.string "standby_day"
     t.string "trading_status"
-    t.integer "seller"
-    t.integer "buyer"
+    t.bigint "seller_id", null: false
+    t.bigint "buyer_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "seller_id"
+    t.index ["buyer_id"], name: "index_items_on_buyer_id"
     t.index ["seller_id"], name: "index_items_on_seller_id"
   end
 
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_012342) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "items", "users", column: "buyer_id"
   add_foreign_key "items", "users", column: "seller_id"
   add_foreign_key "profiles", "users"
   add_foreign_key "sending_destinations", "users"


### PR DESCRIPTION
# What
buyer_id、seller_idのカラム名変更。
データ型をreferencesに変更

# Why
外部キーはカラム名の後ろに_idが必要だが、付けていなかったため。